### PR TITLE
TSK: Clean out warnings from node build

### DIFF
--- a/generators/create-app/templates/cra-redux/src/components/core/pages/About.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/About.jsx
@@ -1,21 +1,29 @@
-import React from 'react'
-import { push } from 'react-router-redux'
+import React, {Component} from 'react';
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 
+class About extends Component {
 
-const About = props => (
-  <div>
-    <h1 className="page-title">About</h1>
-  </div>
-)
+  render() {
+    return(
+      <div>
+        <h1 className="page-title">About</h1>
+      </div>
+    );
+  }
+}
 
 const mapStateToProps = state => ({
-
+  /*
+   * Replace with specific mapping of state to relevant props
+   */
+  state
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-
+  /*
+   * Include action creators used in this component
+   */
 }, dispatch)
 
 export default connect(mapStateToProps, mapDispatchToProps)(About)

--- a/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
+++ b/generators/create-app/templates/cra-redux/src/components/core/pages/Home.jsx
@@ -1,17 +1,11 @@
-import React, {Component, PropTypes} from 'react';
-import { push } from 'react-router-redux'
+import React, {Component} from 'react';
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import autobind from 'autobind-decorator';
 import {
   sampleAction
 } from '../../../reducers/sample/actions'
 
 class Home extends Component {
-
-  constructor(props) {
-    super(props);
-  }
 
   sampleAction() {
     this.props.dispatch.sampleAction()

--- a/generators/create-app/templates/cra-redux/src/index.js
+++ b/generators/create-app/templates/cra-redux/src/index.js
@@ -19,3 +19,5 @@ render(
   </Provider>,
   target
 )
+
+registerServiceWorker();


### PR DESCRIPTION
### Summary
This PR fixes the warnings from the app generator's node build process. 

I also discovered that we are following an unnecessary pattern in our components with the constructor. We don't need to include the constructor and pass `props` to it, unless we are actually going to use the props in the constructor itself! An example use case would be if you needed to set state with props. So I will look to update the component generator as well to remove this pattern. 

More details on it here --> https://discuss.reactjs.org/t/should-we-include-the-props-parameter-to-class-constructors-when-declaring-components-using-es6-classes/2781

### Verification steps
- [x] Pull down code and relink generator locally with `npm link`
- [x] Create a new app with the generator in a different directory `yo react-atomic:create-app`
- [x] Follow the steps to run the app -- ensure no warnings in the app build process. Should see a `Compiled Successfully!` message